### PR TITLE
Implemented relative heatmp coloring

### DIFF
--- a/visualizations/heatmap.js
+++ b/visualizations/heatmap.js
@@ -5,6 +5,16 @@ import '../external/chartjs-chart-matrix.js'
 export default class Heatmap extends MetricChart {
     constructor(parameters = { canvas: null, statistics_container: null }) {
         super(parameters)
+
+        this._maxValue = -1
+    }
+
+    get maxValue() {
+        return this._maxValue
+    }
+
+    set maxValue(value) {
+        this._maxValue = value
     }
 
     _construct_chart_options() {
@@ -113,15 +123,30 @@ export default class Heatmap extends MetricChart {
                 label: this.data_title,
                 type: 'matrix',
                 data: this.data[0].value,
-                backgroundColor: function (drawing_context) {
-                    const value = drawing_context.dataset.data[drawing_context.dataIndex].v
-                    // max 50 commits ho wot calc max value in array?
-                    const alpha = (value * 1.8) / 100 + 0.05
-                    return `rgba(199, 91, 91, ${alpha})`
+                backgroundColor: (drawing_context) => {
+                    if (drawing_context.raw) {
+                        if (this.maxValue === -1) {
+                            this._calculate_max_value()
+                        }
+                        const value = drawing_context.dataset.data[drawing_context.dataIndex].v
+                        const alpha = value / this.maxValue + 0.05
+                        return `rgba(199, 91, 91, ${alpha})`
+                    }
+                    return null
                 },
                 width: ({ chart }) => (chart.chartArea || {}).width / 28,
                 height: ({ chart }) => (chart.chartArea || {}).height / 8
             }
         ]
+    }
+
+    _calculate_max_value() {
+        let max = 0
+        this.data[0].value.forEach((data) => {
+            if (data.v > max) {
+                max = data.v
+            }
+        })
+        this.maxValue = max
     }
 }


### PR DESCRIPTION
Fixes #43 

## Changes
This PR introduces a relative coloring of the heatmaps. We do now have a member variable `maxValue` which is lazy evaluating the max values of the data. This leads to brighter and more colorful heatmap fields! 🥳 

## Screenshots

### Before
![grafik](https://user-images.githubusercontent.com/38314662/131311786-04ca83ca-2a85-44e7-be30-d898b93b603c.png)

### After
![grafik](https://user-images.githubusercontent.com/38314662/131311701-1c10924a-1c6a-406f-97ee-c91d1c0fefd6.png)


## Checklist before merge

**Developer's responsibilities**
* [x] **Assign** one or two developers
* [x] **Change code** if reviewer(s) has/have requested it
* [x] **Pull request build** has passed
* [x] **tested locally** (in at least chrome & firefox if frontend)