### PR TITLE
Team page explanations

### DIFF
--- a/view/team/overview.html
+++ b/view/team/overview.html
@@ -95,7 +95,7 @@
         <h3>Unregistered Collaborators</h3>
     </div>
     <div class='form-group card-body'>
-        <p>This is a small explanation. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut et urna placerat, posuere nunc et, faucibus magna. Proin elementum convallis orci sit amet viverra. Nunc pulvinar nulla rutrum congue auctor.</p>
+        <p>A unregistered collaborator is a Github user, that has not been assigned to a GitHub team of your organisation. When you select a team for your user it will be saved to your configuration file. We recommend you to change the team on GitHub. <a href="https://docs.github.com/en/organizations/organizing-members-into-teams/adding-organization-members-to-a-team">See this guide</a></p>
         <button
             class='form-control btn btn-outline-secondary'
             id='button_load_unregistered_collaborators_from_github'
@@ -123,7 +123,7 @@
         <h3>Anonymous Contributors</h3>
     </div>
     <div class='form-group card-body'>
-        <p>This is a small explanation. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut et urna placerat, posuere nunc et, faucibus magna. Proin elementum convallis orci sit amet viverra. Nunc pulvinar nulla rutrum congue auctor.</p>
+        <p>An anonymous contributor is a commit author in your repository that has no matched GitHub user. As the metrics are built mostly from GitHub Data, contributors with emails that have no matched GitHub user are not included in these metrics. To include an anonymous user in the metrics, inform the user to add the displayed email to his github account. Github then automatically recognizes the email and matches it to the user. <a href="https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-github-user-account/managing-email-preferences/adding-an-email-address-to-your-github-account">See this guide</a></p>
         <button
           class='form-control btn btn-outline-secondary'
           id='button_load_anonymous_contributors_from_github'
@@ -150,7 +150,7 @@
         <h3>Teams</h3>
     </div>
     <div class='form-group card-body'>
-        <p>This is a small explanation. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut et urna placerat, posuere nunc et, faucibus magna. Proin elementum convallis orci sit amet viverra. Nunc pulvinar nulla rutrum congue auctor.</p>
+        <p>Here you have an overview of all the teams in your organization. By clicking <i>Details</i> you can see the individual members of the team.</p>
         <button class='form-control btn btn-outline-secondary' id='button_load_teams_from_github'>
             Load teams from GitHub
         </button>


### PR DESCRIPTION
Fixes #60 

## Changes
This PR adds some explanations to the team site for more usability.

As a follow-up we should think about adding the possibility to add users to teams on the team site.

## Screenshots
![grafik](https://user-images.githubusercontent.com/38314662/134916340-d6ec3e79-c8a2-4680-b2d3-46fe56f21513.png)


## Checklist before merge

**Developer's responsibilities**
* [x] **Assign** one or two developers
* [ ] **Change code** if reviewer(s) has/have requested it
* [x] **Pull request build** has passed
* [x] **tested locally** (in at least chrome & firefox if frontend)